### PR TITLE
Allow null in DateTime reverse transform

### DIFF
--- a/Tests/Form/DataTransformer/CarbonToDateTimeTransformerTest.php
+++ b/Tests/Form/DataTransformer/CarbonToDateTimeTransformerTest.php
@@ -18,4 +18,10 @@ class CarbonToDateTimeTransformerTest extends \PHPUnit_Framework_TestCase
         $transformer = new CarbonToDateTimeTransformer();
         $this->assertInstanceOf('Carbon\Carbon', $transformer->reverseTransform(new \DateTime()));
     }
+
+    public function testReverseTransformWithNull()
+    {
+        $transformer = new CarbonToDateTimeTransformer();
+        $this->assertNull($transformer->reverseTransform(null));
+    }
 }

--- a/src/Form/DataTransformer/CarbonToDateTimeTransformer.php
+++ b/src/Form/DataTransformer/CarbonToDateTimeTransformer.php
@@ -25,6 +25,9 @@ class CarbonToDateTimeTransformer implements DataTransformerInterface
      */
     public function reverseTransform($dateTime)
     {
-        return Carbon::instance($dateTime);
+        if ($dateTime) {
+            return Carbon::instance($dateTime);
+        }
+        return $dateTime;
     }
 }


### PR DESCRIPTION
Hi,

Without this change, give null to Carbon::instance throw an exception.
