### PR TITLE
Check types before data transformation

### DIFF
--- a/src/Form/DataTransformer/CarbonToDateTimeTransformer.php
+++ b/src/Form/DataTransformer/CarbonToDateTimeTransformer.php
@@ -4,6 +4,7 @@ namespace LightSuner\CarbonBundle\Form\DataTransformer;
 
 use Carbon\Carbon;
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /**
  * Tranform Carbon to DateTime
@@ -25,6 +26,14 @@ class CarbonToDateTimeTransformer implements DataTransformerInterface
      */
     public function reverseTransform($dateTime)
     {
-        return Carbon::instance($dateTime);
+        if ($dateTime === null) {
+            return null;
+        }
+
+        if ($dateTime instanceof \DateTime) {
+            return Carbon::instance($dateTime);
+        }
+
+        throw new UnexpectedTypeException($dateTime, '\\DateTime or null');
     }
 }


### PR DESCRIPTION
Check types before data transformation, prevents Carbon from throwing an exception on non-required (null) form fields.
